### PR TITLE
Remove ci keybind

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -84,9 +84,6 @@ noremap <space>/ *
 let &t_SI = "\e]50;CursorShape=1\x7"
 let &t_EI = "\e]50;CursorShape=0\x7"
 
-"change inner | ci to c
-nnoremap c ci
-
 "window
 nnoremap s <Nop>
 nnoremap sj <C-w>j


### PR DESCRIPTION
ci を c に設定していたが、innerというサインが大切なため復活させる。