### PR TITLE
Refactor .tmux.conf

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
-# set prefix to C-s
-set -g prefix C-s
+# set prefix to C-a
+set -g prefix C-a
 
 # reset C-b as prefix key
 unbind C-b

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,22 +1,22 @@
-# prefixキーをC-tに
+# set prefix to C-t
 set -g prefix C-t
 
-# C-bを解除
+# reset C-b as prefix key
 unbind C-b
 
-# キーストロークのディレイを減らす
+# decrease key stroke delay
 set -sg escape-time 1
 
-# 設定ファイルのリロード
+# reload .tmux.conf
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
-# 縦分割
+# split vertically
 bind \ split-window -h
 
-# 横分割
+# split horizontally
 bind - split-window -v
 
-# ペイン移動 like vim
+# move pane
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
@@ -24,65 +24,26 @@ bind l select-pane -R
 bind -r C-h select-window -t :-
 bind -r C-l select-window -t :+
 
-# ペインリサイズ like vim
+# resize pane
 bind -r H resize-pane -L 5
 bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
-# マウス操作を有効にする
+# enable mouse
 setw -g mouse on
 
-# 256色端末
+# 256-color
 set -g default-terminal "screen-256color"
 
-# ステータスバーの色
-set -g status-fg white
-set -g status-bg black
-
-# ウィンドウリストの色
-setw -g window-status-fg cyan
-setw -g window-status-bg default
-setw -g window-status-attr dim
-
-## アクティブウィンドウの色
-setw -g window-status-current-fg white
-setw -g window-status-current-bg red
-setw -g window-status-current-attr bright
-
-# ペインボーダーの色を設定する
-set -g pane-border-fg green
-set -g pane-border-bg black
-
-# アクティブなペインを目立たせる
-set -g pane-active-border-fg white
-set -g pane-active-border-bg yellow
-
-# コマンドラインの色を設定する
-set -g message-fg white
-set -g message-bg black
-set -g message-attr bright
-
-# ステータスバーを設定する
-## 左パネルを設定する
-set -g status-left-length 40
-set -g status-left "#[fg=green]Session: #S #[fg=yellow]#I #[fg=cyan]#P"
-## 右パネルを設定する
-set -g status-right "#[fg=cyan][%Y-%m-%d(%a) %H:%M]"
-## リフレッシュの間隔を設定する(デフォルト 15秒)
+# status bar
 set -g status-interval 60
-## ウィンドウリストの位置を中心寄せにする
-set -g status-justify centre
-## ヴィジュアルノーティフィケーションを有効にする
 setw -g monitor-activity on
 set -g visual-activity on
 
-# コピーモードを設定する
-## viのキーバインドを使用する
+# copy mode
 setw -g mode-keys vi
-## クリップボード共有を有効にする
 set-option -g default-command "exec reattach-to-user-namespace -l $SHELL"
-## コピーモードの操作をvi風に設定する
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 unbind -T copy-mode-vi Enter

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
-# set prefix to C-t
-set -g prefix C-t
+# set prefix to C-k
+set -g prefix C-k
 
 # reset C-b as prefix key
 unbind C-b

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
-# set prefix to C-k
-set -g prefix C-k
+# set prefix to C-s
+set -g prefix C-s
 
 # reset C-b as prefix key
 unbind C-b


### PR DESCRIPTION
- コメントを英語に
- style/colorのデフォルト設定を削除
- prefix-keyをやっぱりC-aにした（C-tだとunite.vimのタブで開くができない）