### PR TITLE
Feature/vim-markdown

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -36,11 +36,13 @@ if dein#load_state('/Users/hiromumasuda/.cache/dein')
   call dein#add('pangloss/vim-javascript')
   call dein#add('mxw/vim-jsx')
   call dein#add('hail2u/vim-css3-syntax')
-  call dein#add('taichouchou2/html5.vim')
   call dein#add('kchmck/vim-coffee-script')
   call dein#add('cakebaker/scss-syntax.vim')
   call dein#add('airblade/vim-gitgutter')
   call dein#add('szw/vim-tags')
+  call dein#add('plasticboy/vim-markdown')
+  call dein#add('kannokanno/previm')
+  call dein#add('tyru/open-browser.vim')
 
   " You can specify revision/branch/tag.
   " call dein#add('Shougo/deol.nvim', { 'rev': 'a1b5108fd' })
@@ -219,3 +221,12 @@ set tags=../tags
 "lightline.vim
 """"""""""""""""""""""""""
 set laststatus=2
+
+""""""""""""""""""""""""""
+"markdown
+""""""""""""""""""""""""""
+  autocmd BufRead,BufNewFile *.mkd  set filetype=markdown
+  autocmd BufRead,BufNewFile *.md  set filetype=markdown
+  " Need: kannokanno/previm
+  nnoremap <silent> <C-b> :PrevimOpen<CR>
+  let g:vim_markdown_folding_disabled=1

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 ### dein
 - [Shougo/dein.vim - ReadMe](https://github.com/Shougo/dein.vim)
 - [Shougo/dein.vim - Command](https://github.com/Shougo/dein.vim/blob/master/doc/dein.txt)
+
+```
+:call dein#install()
+:call dein#update()
+```


### PR DESCRIPTION
```
Ctrl + b
```
でmarkdownプレビューをオープン

`'taichouchou2/html5.vim'`はバグがあったので削除